### PR TITLE
wFix: Change default fetch URL to local backend in chat component

### DIFF
--- a/frontend/components/chat.tsx
+++ b/frontend/components/chat.tsx
@@ -468,7 +468,7 @@ export function Chat({ selectedModel, onModelChange, apiTokens }: ChatProps) {
         }
       }
 
-      const response = await fetch("https://api.deepclaude.com", {
+      const response = await fetch("http://127.0.0.1:1337", {
         method: "POST",
         signal: controller.signal,
         headers: {


### PR DESCRIPTION
This commit updates the default `fetch` URL in `frontend/components/chat.tsx` from `https://api.deepclaude.com` to `http://127.0.0.1:1337`.

**Reasoning:**

The previous default configuration unintentionally directed API requests to the hosted `api.deepclaude.com` endpoint, even when users were running the frontend locally. This could lead to users inadvertently sending their API keys to the external server if they used the chat interface without realizing this default setting.

This change ensures that by default, the frontend communicates with the local backend server running on `http://127.0.0.1:1337`, aligning with the expected behavior for users who are self-hosting the application.

**Security Improvement:**

By pointing to the local backend by default, this commit reduces the risk of users unintentionally exposing their API keys to an external server.

Users who intend to use the managed `api.deepclaude.com` API can still manually change the fetch URL, but the default is now correctly configured for local development and self-hosting scenarios.